### PR TITLE
Fix bug when using complex input

### DIFF
--- a/ols.py
+++ b/ols.py
@@ -212,7 +212,7 @@ def ols(x, h, size=None, nfft=None, out=None, rfftn=None, irfftn=None, mode='con
   assert len(x.shape) == len(size)
   assert len(x.shape) == len(nfft)
 
-  hpre = prepareh(h, nfft)
+  hpre = prepareh(h, nfft, rfftn=rfftn)
   if out is None:
     out = np.zeros(x.shape, dtype=x.dtype)
 


### PR DESCRIPTION
Without this, running the test with complex output produces the following error:

```
(...)
>     output = irfftn(rf * hfftconj, nfft)
E     ValueError: operands could not be broadcast together with shapes (35,35) (35,18)
```