### PR TITLE
Improve compatibility with old numpys

### DIFF
--- a/ols.py
+++ b/ols.py
@@ -58,7 +58,8 @@ def prepareh(h, nfft: List[int], rfftn=None):
   `rfftn` defaults to `numpy.fft.rfftn` and may be overridden.
   """
   rfftn = rfftn or np.fft.rfftn
-  return np.conj(rfftn(np.flip(np.conj(h)), nfft))
+  axes = np.arange(len(h.shape))
+  return np.conj(rfftn(np.flip(np.conj(h), axis=axes), nfft))
 
 
 def slice2range(s: slice):


### PR DESCRIPTION
The `axis` argument was required in `np.flip` before numpy 1.15.