### PR TITLE
Actually improve compatibility with old numpy

### DIFF
--- a/ols.py
+++ b/ols.py
@@ -48,6 +48,31 @@ from array_range import array_range
 from typing import List
 
 
+def flip_all(array):
+    """Flip all array dimensions (compatibility with old numpy)
+
+    Substitutes for np.flip(array, axis=None) introduced in Numpy 1.15
+
+    Examples
+    --------
+    >>> array = np.array([[[0, 1], [2, 3]], [[4, 5], [6, 7]]])
+    >>> flipped_array = np.array([[[7, 6], [5, 4]], [[3, 2], [1, 0]]])
+    >>> np.all(flipped_array == flip_all(array))
+    True
+    """
+    for dim in range(len(array.shape)):
+        array = np.flip(array, dim)
+    return array
+
+
+try:
+    from numpy import flip
+    flip(np.zeros((0, 0)))
+except TypeError:
+    flip = flip_all
+
+
+  
 def prepareh(h, nfft: List[int], rfftn=None):
   """Pre-process a filter array
 
@@ -58,8 +83,8 @@ def prepareh(h, nfft: List[int], rfftn=None):
   `rfftn` defaults to `numpy.fft.rfftn` and may be overridden.
   """
   rfftn = rfftn or np.fft.rfftn
-  axes = np.arange(len(h.shape))
-  return np.conj(rfftn(np.flip(np.conj(h), axis=axes), nfft))
+  return np.conj(rfftn(flip(np.conj(h)), nfft))
+
 
 
 def slice2range(s: slice):


### PR DESCRIPTION
I mistakenly tested the previous fix with the new numpy, so it was too easy. This one works.
I'm testing only once if the numpy version accepts the bare "axis" argument, and use the new machinery only in this case.
I do this because this is slower than the numpy implementation.
Feel free to reject this change, and go back to the old behavior. My previous PR was rather ineffective :)